### PR TITLE
fix(security): avoid serializing User in OnRegistrationCompleteEvent (CVE-2017-2603)

### DIFF
--- a/source/xzs/pom.xml
+++ b/source/xzs/pom.xml
@@ -19,6 +19,8 @@
         <java.version>1.8</java.version>
         <postgresql.version>42.2.6</postgresql.version>
         <spring.boot.version>2.1.6.RELEASE</spring.boot.version>
+        <!-- Preserve previous default: unit tests off unless -Dskip.unit.tests=false -->
+        <skip.unit.tests>true</skip.unit.tests>
     </properties>
 
 
@@ -176,7 +178,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skipTests>true</skipTests>
+                    <skipTests>${skip.unit.tests}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/source/xzs/src/main/java/com/mindskip/xzs/event/OnRegistrationCompleteEvent.java
+++ b/source/xzs/src/main/java/com/mindskip/xzs/event/OnRegistrationCompleteEvent.java
@@ -12,7 +12,10 @@ import org.springframework.context.ApplicationEvent;
 public class OnRegistrationCompleteEvent extends ApplicationEvent {
 
 
-    private final User user;
+    /**
+     * Avoid serializing full user details when this event is persisted.
+     */
+    private final transient User user;
 
 
     /**

--- a/source/xzs/src/test/java/com/mindskip/xzs/event/OnRegistrationCompleteEventSerializationTest.java
+++ b/source/xzs/src/test/java/com/mindskip/xzs/event/OnRegistrationCompleteEventSerializationTest.java
@@ -1,0 +1,38 @@
+package com.mindskip.xzs.event;
+
+import com.mindskip.xzs.domain.User;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.Assert.assertNull;
+
+public class OnRegistrationCompleteEventSerializationTest {
+
+    @Test
+    public void dedicatedUserFieldIsNotSerialized() throws Exception {
+        User user = new User();
+        user.setId(1);
+        user.setUserName("alice");
+        user.setPassword("secret-password");
+
+        OnRegistrationCompleteEvent event = new OnRegistrationCompleteEvent(user);
+
+        byte[] bytes;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(event);
+            bytes = baos.toByteArray();
+        }
+
+        OnRegistrationCompleteEvent deserialized;
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            deserialized = (OnRegistrationCompleteEvent) ois.readObject();
+        }
+
+        assertNull("transient user field should not survive serialization", deserialized.getUser());
+    }
+}


### PR DESCRIPTION
## Summary

Hardens `OnRegistrationCompleteEvent` against Java serialization leaking the full `User` graph (including password), following the same pattern as [Jenkins CVE-2017-2603 / commit 3cd946c](https://github.com/jenkinsci/jenkins/commit/3cd946cbef82c6da5ccccf3890d0ae4e091c4265): mark the dedicated `user` field `transient`, add a serialization round-trip test, and parameterize Surefire so tests can run with `-Dskip.unit.tests=false` while keeping the previous default (tests skipped).

## Reproduction (before)

- `source/xzs/src/main/java/com/mindskip/xzs/event/OnRegistrationCompleteEvent.java` had `private final User user;` (non-transient).
- Any code path that serializes the event could persist credentials from `com.mindskip.xzs.domain.User`.

## Fix

- `private final transient User user` + short Javadoc.
- New `OnRegistrationCompleteEventSerializationTest`: after `ObjectOutputStream` / `ObjectInputStream`, `getUser()` is `null`.
- `pom.xml`: `<skip.unit.tests>true</skip.unit.tests>` and `<skipTests>${skip.unit.tests}</skipTests>`.

## Verification

```bash
cd source/xzs
mvn test -Dskip.unit.tests=false
```

Observed: **BUILD SUCCESS**; Surefire runs `OnRegistrationCompleteEventSerializationTest`.

```bash
mvn test
```

Observed: **BUILD SUCCESS**; tests still skipped by default.

## Scope

- Application code + one test class; no vendored trees changed.

## Limitation

`ApplicationEvent` still receives `super(user)`; this PR addresses the duplicate `user` field pattern aligned with the upstream fix. Further hardening could avoid passing the full `User` as the event source if required.
